### PR TITLE
Avoid setup_requires offline installation issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
 
 [options]
 packages = find:
-setup_requires = setuptools_scm
 install_requires =
     attrs>=17.4.0
     functools32;python_version<'3'


### PR DESCRIPTION
Currently, it's not possible to install jsonschema offline, as pip cannot found setup_requires dependencies.
See https://www.scivision.dev/setuptools-pyproject-toml-offline/ and https://stackoverflow.com/questions/27307082/install-package-which-has-setup-requires-from-local-source-distributions.
Simply removing the option from setup.cfg do the trick.